### PR TITLE
Fix updateExpenseStatus call

### DIFF
--- a/components/DashboardComponents.tsx
+++ b/components/DashboardComponents.tsx
@@ -15,7 +15,7 @@ const ExpenseListItem: React.FC<{ expense: Expense, onUpdate: () => void }> = ({
     if (!user || (user.role !== UserRole.APPROVER && user.role !== UserRole.ADMIN)) return;
     setIsUpdating(true);
     try {
-      await apiService.updateExpenseStatus(expense.id, status, user.role);
+      await apiService.updateExpenseStatus(expense.id, status, user.email || '', user.role);
       onUpdate(); // Refresh the list
     } catch (error) {
       console.error(`Failed to ${status === ExpenseStatus.APPROVED ? 'approve' : 'decline'} expense:`, error);

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -112,6 +112,22 @@ export const apiService = {
     return updatedExpense;
   },
 
+  // Convenience method used by the dashboard to update an expense's status.
+  // Delegates to the appropriate approve or decline endpoint based on the
+  // desired status.
+  updateExpenseStatus: async (
+    expenseId: string,
+    status: ExpenseStatus.APPROVED | ExpenseStatus.DECLINED,
+    userEmail: string,
+    userRole: UserRole
+  ): Promise<Expense> => {
+    if (status === ExpenseStatus.APPROVED) {
+      return apiService.approveExpense(expenseId, userEmail, userRole);
+    } else {
+      return apiService.declineExpense(expenseId, userEmail, userRole);
+    }
+  },
+
   // --- Users ---
   getUsers: async (): Promise<AppUser[]> => {
     const { users } = await fetchApi<{ users: AppUser[] }>(`${API_BASE_URL}/users`);


### PR DESCRIPTION
## Summary
- add `updateExpenseStatus` helper to apiService
- include user email when updating expense status

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685a694660288331b127c7593a795603