### PR TITLE
Add version display in footer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,7 +8,7 @@ import { DashboardScreen } from './components/DashboardComponents';
 import { SettingsScreen } from './components/SettingsScreen';
 import { AddExpenseScreen } from './components/AddExpenseScreen';
 import { Navbar, LoadingSpinner } from './components/shared/UIElements';
-import { APP_NAME } from './constants';
+import { APP_NAME, APP_VERSION } from './constants';
 
 interface AuthContextType {
   user: User | null;
@@ -163,7 +163,7 @@ const AppContent: React.FC = () => {
         </Routes>
       </main>
       <footer className="bg-slate-800 text-white text-center p-4 mt-auto">
-        &copy; {new Date().getFullYear()} {APP_NAME}. All rights reserved.
+        &copy; {new Date().getFullYear()} {APP_NAME} v{APP_VERSION}. All rights reserved.
       </footer>
     </div>
   );

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,6 @@
 
 export const APP_NAME = "Expense Approval System";
+export const APP_VERSION = "1.0.0";
 
 export const CURRENCIES = ['USD', 'EUR', 'GBP'];
 


### PR DESCRIPTION
## Summary
- expose `APP_VERSION` constant
- show app version in the footer

## Testing
- `npm run build` *(fails: Missing script "build")*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685a6d8ea2488331ba4b55a5d88d67a9