### PR TITLE
Fix login email normalization

### DIFF
--- a/components/DashboardComponents.tsx
+++ b/components/DashboardComponents.tsx
@@ -116,12 +116,8 @@ export const DashboardScreen: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const allExpenses = await apiService.getExpenses();
-      if (user?.role === UserRole.SUBMITTER) {
-        setExpenses(allExpenses.filter(exp => exp.submitterEmail === user.email).sort((a,b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime() ));
-      } else { // Admin and Approver see all
-        setExpenses(allExpenses.sort((a,b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime() ));
-      }
+      const allExpenses = await apiService.getExpenses(user?.email, user?.role);
+      setExpenses(allExpenses.sort((a,b) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()));
     } catch (err) {
       setError('Failed to load expenses.');
       console.error(err);

--- a/server.cjs
+++ b/server.cjs
@@ -95,29 +95,33 @@ app.post('/api/login', checkDbInitialized, async (req, res) => {
   try {
     const { usernameOrEmail, password } = req.body;
 
-    if (!usernameOrEmail || !password) {
+    // Normalize input to avoid case or whitespace issues
+    const normalizedUser = (usernameOrEmail || '').trim().toLowerCase();
+    const normalizedPass = (password || '').trim();
+
+    if (!normalizedUser || !normalizedPass) {
       return res.status(400).json({ message: 'Username/Email and password are required.' });
     }
 
-    if (usernameOrEmail.toLowerCase() === 'admin' && password === 'admin') {
+    if (normalizedUser === 'admin' && normalizedPass === 'admin') {
       return res.json({ user: { id: 'admin-user', username: 'admin', role: 'ADMIN' } });
     }
 
     // Check new users table first
-    const user = await database.getUserByEmail(usernameOrEmail);
-    if (user && password === usernameOrEmail) {
-      return res.json({ user: { id: user.id, username: usernameOrEmail, email: usernameOrEmail, role: user.role } });
+    const user = await database.getUserByEmail(normalizedUser);
+    if (user && normalizedPass === normalizedUser) {
+      return res.json({ user: { id: user.id, username: normalizedUser, email: normalizedUser, role: user.role } });
     }
 
     // Fallback to legacy settings for backward compatibility
     const settings = await database.getSettings();
 
-    if (settings.submitterEmail && usernameOrEmail === settings.submitterEmail && password === settings.submitterEmail) {
-      return res.json({ user: { id: `submitter-${usernameOrEmail}`, username: usernameOrEmail, email: usernameOrEmail, role: 'SUBMITTER' } });
+    if (settings.submitterEmail && normalizedUser === settings.submitterEmail.toLowerCase() && normalizedPass === settings.submitterEmail.toLowerCase()) {
+      return res.json({ user: { id: `submitter-${normalizedUser}`, username: normalizedUser, email: normalizedUser, role: 'SUBMITTER' } });
     }
 
-    if (settings.approverEmail && usernameOrEmail === settings.approverEmail && password === settings.approverEmail) {
-      return res.json({ user: { id: `approver-${usernameOrEmail}`, username: usernameOrEmail, email: usernameOrEmail, role: 'APPROVER' } });
+    if (settings.approverEmail && normalizedUser === settings.approverEmail.toLowerCase() && normalizedPass === settings.approverEmail.toLowerCase()) {
+      return res.json({ user: { id: `approver-${normalizedUser}`, username: normalizedUser, email: normalizedUser, role: 'APPROVER' } });
     }
 
     return res.status(401).json({ message: 'Invalid credentials or user not configured.' });
@@ -162,7 +166,17 @@ app.post('/api/settings', checkDbInitialized, async (req, res) => {
 // GET /api/expenses
 app.get('/api/expenses', checkDbInitialized, async (req, res) => {
   try {
-    const expenses = await database.getExpenses();
+    const { userEmail = '', userRole = '' } = req.query;
+    let expenses;
+
+    if (userRole === 'APPROVER') {
+      expenses = await database.getExpensesForApprover(String(userEmail).toLowerCase());
+    } else if (userRole === 'SUBMITTER') {
+      expenses = await database.getExpensesForSubmitter(String(userEmail).toLowerCase());
+    } else {
+      expenses = await database.getExpenses();
+    }
+
     res.json({ expenses });
   } catch (error) {
     console.error('Get expenses error:', error);
@@ -244,6 +258,7 @@ app.get('/api/users', checkDbInitialized, async (req, res) => {
 app.post('/api/users', checkDbInitialized, async (req, res) => {
   try {
     const { email, role } = req.body;
+    const normalizedEmail = (email || '').trim().toLowerCase();
     
     if (!email || !role) {
       return res.status(400).json({ message: 'Email and role are required.' });
@@ -253,14 +268,14 @@ app.post('/api/users', checkDbInitialized, async (req, res) => {
       return res.status(400).json({ message: 'Role must be SUBMITTER or APPROVER.' });
     }
     
-    const existingUser = await database.getUserByEmail(email);
+    const existingUser = await database.getUserByEmail(normalizedEmail);
     if (existingUser) {
       return res.status(400).json({ message: 'User with this email already exists.' });
     }
     
     const newUser = {
       id: `user-${Date.now()}-${crypto.randomBytes(3).toString('hex')}`,
-      email,
+      email: normalizedEmail,
       role,
       createdAt: new Date().toISOString()
     };

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -69,8 +69,12 @@ export const apiService = {
   },
 
   // --- Expenses ---
-  getExpenses: async (): Promise<Expense[]> => {
-    const { expenses } = await fetchApi<{ expenses: Expense[] }>(`${API_BASE_URL}/expenses`);
+  getExpenses: async (userEmail?: string, userRole?: UserRole): Promise<Expense[]> => {
+    const params = new URLSearchParams();
+    if (userEmail) params.append('userEmail', userEmail);
+    if (userRole) params.append('userRole', userRole);
+    const query = params.toString() ? `?${params.toString()}` : '';
+    const { expenses } = await fetchApi<{ expenses: Expense[] }>(`${API_BASE_URL}/expenses${query}`);
     return expenses;
   },
 


### PR DESCRIPTION
## Summary
- normalize login input to avoid case/spacing mismatches
- store new user emails in lowercase to match approval records
- filter expenses server-side so approvers only see items awaiting their review

## Testing
- ❌ `npm test` (failed to run tests: Missing script)
- ❌ `npm run lint` (failed to run lint: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_685a6bfea20c833180f278752583128d